### PR TITLE
Adds error for http status code 304 (for changefeed) in ListDocumentRaw()

### DIFF
--- a/client_operations.go
+++ b/client_operations.go
@@ -34,6 +34,9 @@ const (
 
 	// ErrResourceNotFound is returned when a resource is not found
 	ErrResourceNotFound = Error("interstellar: resource not found")
+
+	// ErrResourceNotModified is returned from an http status code 304
+	ErrResourceNotModified = Error("interstellar: resource not modified")
 )
 
 // PaginateRawResources is run by the List* operations with each page of results from the API.
@@ -163,6 +166,9 @@ func (c *Client) ListResources(ctx context.Context, key string, request ClientRe
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode == http.StatusNotModified {
+				return ErrResourceNotModified
+			}
 			return rest.NewErrorHTTPResponse(resp)
 		}
 		meta := GetResponseMetadata(resp)

--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,8 @@
 
 package interstellar
 
+import "net/http"
+
 // Error is an interstellar generated error
 // This type is an alias for 'string' and is used to ensure the interstellar sential errors can be made constant
 type Error string
@@ -23,4 +25,16 @@ type Error string
 // Error implements the error interface for the Error type
 func (e Error) Error() string {
 	return string(e)
+}
+
+// StatusCode relay the status code
+func (e Error) Status() int {
+	switch e {
+	case ErrResourceNotModified:
+		return http.StatusNotModified
+	case ErrResourceNotFound:
+		return http.StatusNotFound
+	default:
+		return 0
+	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -16,7 +16,10 @@
 
 package interstellar
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 func TestErrorString(t *testing.T) {
 	err := Error("test error")
@@ -24,6 +27,18 @@ func TestErrorString(t *testing.T) {
 		t.Fatalf("constant equality check failed")
 	}
 	if err != Error("test error") {
+		t.Fatalf("constant equality check failed")
+	}
+}
+
+func TestErrorStatus(t *testing.T) {
+	var err error = ErrResourceNotModified
+	type hasStatus interface{ Status() int }
+	if hs, ok := err.(hasStatus); !ok || hs.Status() != http.StatusNotModified {
+		t.Fatalf("constant equality check failed")
+	}
+	err = ErrResourceNotFound
+	if hs, ok := err.(hasStatus); !ok || hs.Status() != http.StatusNotFound {
 		t.Fatalf("constant equality check failed")
 	}
 }


### PR DESCRIPTION
When calling `ListDocumentsRaw` with 
```golang
interstellar.CommonRequestOptions{
		ChangeFeed:  true,
		IfNoneMatch: <some etag>,
	}
```
we can get a response status code `304` when there's no new documents to report. Right now anything that is not a `200` is a generic error. This update adds a new function on the interstellar Error type which returns a status code for select error messages.